### PR TITLE
Raise exception for processes that terminate with non-zero exit code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sdf_pipeline"
-version = "0.2.0"
+version = "1.0.0"
 
 [project.optional-dependencies]
 dev = ["pytest"]

--- a/src/sdf_pipeline/core.py
+++ b/src/sdf_pipeline/core.py
@@ -1,7 +1,8 @@
-import multiprocessing
 import gzip
+from concurrent.futures import ProcessPoolExecutor, as_completed, process
 from typing import Callable, TYPE_CHECKING
 from collections.abc import Generator
+from sdf_pipeline import logger
 
 if TYPE_CHECKING:
     # https://adamj.eu/tech/2021/05/13/python-type-hints-how-to-fix-circular-imports/
@@ -13,75 +14,58 @@ def read_records_from_gzipped_sdf(sdf_path: str) -> Generator[str, None, None]:
     current_record = ""
     # TODO: guard file opening.
     with gzip.open(sdf_path, "rb") as gzipped_sdf:
-        # decompress SDF line-by-line to avoid loading entire SDF into memory
+        # Decompress SDF line-by-line to avoid loading entire SDF into memory.
         for decompressed_line in gzipped_sdf:
             decoded_line = decompressed_line.decode("utf-8", "backslashreplace")
             current_record += decoded_line
             if decoded_line.strip() == "$$$$":
                 # TODO: harden SDF parsing according to
-                # http://www.dalkescientific.com/writings/diary/archive/2020/09/18/handling_the_sdf_record_delimiter.html
+                # http://www.dalkescientific.com/writings/diary/archive/2020/09/18/handling_the_sdf_record_delimiter.html.
                 yield current_record
                 current_record = ""
 
-
-def _produce_molfiles(
-    molfile_queue: multiprocessing.Queue, sdf_path: str, n_poison_pills: int
-) -> None:
-    for molfile in read_records_from_gzipped_sdf(sdf_path):
-        molfile_queue.put(molfile)
-
-    for _ in range(n_poison_pills):
-        molfile_queue.put("DONE")  # poison pill: tell consumer processes we're done
-
-
-def _consume_molfiles(
-    molfile_queue: multiprocessing.Queue,
-    result_queue: multiprocessing.Queue,
-    consumer_function: Callable,
-) -> None:
-    for molfile in iter(molfile_queue.get, "DONE"):
-        result_queue.put(consumer_function(molfile))
-
-    result_queue.put(f"DONE")
+    return None
 
 
 def run(
-    sdf_path: str,
-    consumer_function: Callable,
-    number_of_consumer_processes: int,
+    sdf_path: str, consumer_function: Callable, number_of_consumer_processes: int
 ) -> Generator["ConsumerResult", None, None]:
-    molfile_queue: multiprocessing.Queue = multiprocessing.Queue()  # TODO: limit size?
-    result_queue: multiprocessing.Queue = multiprocessing.Queue()
 
-    producer_process = multiprocessing.Process(
-        target=_produce_molfiles,
-        args=(molfile_queue, sdf_path, number_of_consumer_processes),
-    )
-    producer_process.start()
+    try:
+        with ProcessPoolExecutor(
+            max_workers=number_of_consumer_processes
+        ) as process_pool:
+            futures = (
+                process_pool.submit(consumer_function, molfile)
+                for molfile in read_records_from_gzipped_sdf(sdf_path)
+            )
+            """
+            `as_completed` isn't iterating `futures` lazily. It instantiates a set of futures:
+            https://github.com/python/cpython/blob/f383ca1a6fa1a2a83c8c1a0e56cf997c77fa2893/Lib/concurrent/futures/_base.py#L220.
+            In case of memory constraints, consider chunking `futures`: https://bugs.python.org/issue34168.
+            """
+            for future in as_completed(futures):
+                exception = future.exception()
+                if exception is not None:
+                    logger.error(f"could not process {sdf_path}: {exception}")
 
-    consumer_processes = [
-        multiprocessing.Process(
-            target=_consume_molfiles,
-            args=(
-                molfile_queue,
-                result_queue,
-                consumer_function,
-            ),
-        )
-        for process_id in range(number_of_consumer_processes)
-    ]
-    for consumer_process in consumer_processes:
-        consumer_process.start()
+                    raise exception  # Dead programs don't tell lies.
 
-    number_of_finished_consumer_processes = 0
-    while number_of_finished_consumer_processes < number_of_consumer_processes:
-        result = result_queue.get()  # blocks until result is available
-        if result == "DONE":
-            number_of_finished_consumer_processes += 1
-            continue
-        yield result
+                yield future.result()
 
-    # processes won't join before all queues their interacting with are empty
-    producer_process.join()
-    for consumer_process in consumer_processes:
-        consumer_process.join()
+    except process.BrokenProcessPool as exception:
+        """
+        `exception` can be thrown in two ways with (slightly) different messages:
+        1) While processing a future in the `as_completed` loop above,
+            in which case `exception` is re-raised below.
+            See https://github.com/python/cpython/blob/7f074a771bc4e3e299799fabf9b054a03f6693d2/Lib/concurrent/futures/process.py#L489
+            and https://discuss.python.org/t/as-completed-not-yielding-futures-that-raised-until-pool-exits/39920.
+        2) While submitting a task to the `process_pool`.
+            See https://github.com/python/cpython/blob/7f074a771bc4e3e299799fabf9b054a03f6693d2/Lib/concurrent/futures/process.py#L793.
+        We need this `except` block in order to catch 2). For 1), the inner `raise` would be sufficient.
+        """
+        logger.error(f"could not process {sdf_path}: {exception}")
+
+        raise exception
+
+    return None

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -3,21 +3,44 @@ import sqlite3
 import pytest
 import logging
 import json
+import ctypes
+import timeit
 from operator import add
 from functools import reduce
 from pathlib import Path
 from typing import Callable
-from sdf_pipeline import drivers
+from functools import partial
+from concurrent.futures.process import BrokenProcessPool
+from sdf_pipeline import drivers, core
 
 
-def regression_consumer(
-    molfile: str, get_molfile_id: Callable
-) -> drivers.ConsumerResult:
+def consumer(molfile: str, get_molfile_id: Callable) -> drivers.ConsumerResult:
     return drivers.ConsumerResult(
         get_molfile_id(molfile),
         "regression",
         str(len(molfile)),
     )
+
+
+def busy_consumer(molfile: str, get_molfile_id: Callable) -> drivers.ConsumerResult:
+    n = 0
+    for i in range(100):
+        n += sum([len(line) ** i for line in molfile.split("\n")])
+    return drivers.ConsumerResult(
+        get_molfile_id(molfile),
+        "regression",
+        n,
+    )
+
+
+def segfaulting_consumer(
+    molfile: str, get_molfile_id: Callable
+) -> drivers.ConsumerResult:
+    ctypes.string_at(0)
+
+
+def raising_consumer(molfile: str, get_molfile_id: Callable) -> drivers.ConsumerResult:
+    1 / 0
 
 
 @pytest.fixture
@@ -45,7 +68,7 @@ def test_regression_reference_driver(sdf_path, tmp_path):
     exit_code = drivers.regression_reference(
         sdf_path=sdf_path,
         reference_path=tmp_path / "regression_reference.sqlite",
-        consumer_function=regression_consumer,
+        consumer_function=consumer,
         get_molfile_id=_get_mcule_id,
         number_of_consumer_processes=2,
     )
@@ -63,7 +86,7 @@ def test_regression_driver(sdf_path, reference_path, caplog):
     exit_code = drivers.regression(
         sdf_path=sdf_path,
         reference_path=reference_path,
-        consumer_function=regression_consumer,
+        consumer_function=consumer,
         get_molfile_id=_get_mcule_id,
         number_of_consumer_processes=2,
     )
@@ -77,3 +100,59 @@ def test_regression_driver(sdf_path, reference_path, caplog):
         "info": "regression",
         "diff": '{"current": "926", "reference": "42"}',
     }
+
+
+def test_core_raises_on_exception(sdf_path, caplog):
+    caplog.set_level(logging.ERROR, logger="sdf_pipeline")
+    with pytest.raises(ZeroDivisionError):
+        for _ in core.run(
+            sdf_path=str(sdf_path),
+            consumer_function=partial(raising_consumer, get_molfile_id=_get_mcule_id),
+            number_of_consumer_processes=2,
+        ):
+            pass
+    assert (
+        caplog.records[-1].message == f"could not process {sdf_path}: division by zero"
+    )
+
+
+def test_core_raises_on_segfault(sdf_path, caplog):
+    caplog.set_level(logging.ERROR, logger="sdf_pipeline")
+    with pytest.raises(BrokenProcessPool):
+        for _ in core.run(
+            sdf_path=str(sdf_path),
+            consumer_function=partial(
+                segfaulting_consumer, get_molfile_id=_get_mcule_id
+            ),
+            number_of_consumer_processes=2,
+        ):
+            pass
+    # See comment in `core.run` for why there's two alternative messages.
+    assert caplog.records[-1].message in [
+        f"could not process {sdf_path}: A process in the process pool was terminated abruptly while the future was running or pending.",
+        f"could not process {sdf_path}: A child process terminated abruptly, the process pool is not usable anymore",
+    ]
+
+
+@pytest.mark.skip
+def test_performance(sdf_path):
+    def run_core(n_processes):
+        def _run_core():
+            for _ in core.run(
+                sdf_path=str(sdf_path),
+                consumer_function=partial(busy_consumer, get_molfile_id=_get_mcule_id),
+                number_of_consumer_processes=n_processes,
+            ):
+                pass
+
+        return _run_core
+
+    previous_execution_time = 0
+    for n in [1, 2, 4, 8, 16]:
+        execution_time = timeit.Timer(run_core(n)).timeit(1)
+        print(f"{n} processes finished in {execution_time} seconds.")
+
+        if previous_execution_time:
+            assert execution_time < previous_execution_time
+
+        previous_execution_time = execution_time


### PR DESCRIPTION
Prior to this commit, `core.run` would wait for results indefinitely when a child process terminated with a non-zero exit code (e.g., segfault). This was due to the fact that `multiprocessing.Pool` does not raise an exception ( https://github.com/python/cpython/issues/66587 ). This commit replaces `multiprocessing.Pool` with `concurrent.futures.ProcessPoolExecutor`. In contrast to the former, the latter raises an exception in case a child process terminates with a non-zero exit code.